### PR TITLE
Fix bugs with LC_TIME for various platforms

### DIFF
--- a/src/rolfing_django_project/web_app/templatetags/date_period.py
+++ b/src/rolfing_django_project/web_app/templatetags/date_period.py
@@ -4,13 +4,28 @@ from django import template
 
 from web_app.models import EventModel
 
+from rolfing_django_project import settings
+
 register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
 def date_period(context, event: EventModel):
     """ Glues dates to period like:  24 Nov 2023 - 10 Dec 2023 -> 24 Nov - 10 Dec 2023"""
-    locale.setlocale(locale.LC_ALL, context.request.COOKIES.get('lang_code', ''))
+    LC_TIME_STRINGS = {
+        'ru': ('ru_RU.utf8', 'ru', 'Russian'),
+        'en': ('en_US.utf8', 'en', 'English'),
+    }
+
+    lang_code = context.request.COOKIES.get('lang_code', settings.LANGUAGE_CODE.casefold())
+    LC_TIMEs = LC_TIME_STRINGS.get(lang_code)
+    for LC_TIME_ in LC_TIMEs:
+        try:
+            locale.setlocale(locale.LC_TIME, LC_TIME_)
+            break
+        except:
+            print(f'{__name__}.\nWrong {LC_TIME_=}. Skipped.') if settings.DEBUG else None
+            continue
     format = '%d %b %Y'
     start_date:str = event.start_date.strftime(format)
     end_date:str = event.end_date.strftime(format)


### PR DESCRIPTION
Used try-except for 'en_US.utf8', 'en', 'English' variations.